### PR TITLE
Allow tuning loader options

### DIFF
--- a/src/main/scala/io/circe/yaml/Parser.scala
+++ b/src/main/scala/io/circe/yaml/Parser.scala
@@ -5,9 +5,9 @@ import io.circe._
 import io.circe.yaml.Parser._
 import org.yaml.snakeyaml.constructor.SafeConstructor
 import org.yaml.snakeyaml.nodes._
-import org.yaml.snakeyaml.{LoaderOptions, Yaml}
+import org.yaml.snakeyaml.{ LoaderOptions, Yaml }
 
-import java.io.{Reader, StringReader}
+import java.io.{ Reader, StringReader }
 import scala.collection.JavaConverters._
 
 final case class Parser(

--- a/src/main/scala/io/circe/yaml/Parser.scala
+++ b/src/main/scala/io/circe/yaml/Parser.scala
@@ -1,13 +1,13 @@
 package io.circe.yaml
 
-import Parser._
 import cats.syntax.either._
 import io.circe._
-import java.io.{ Reader, StringReader }
-import org.yaml.snakeyaml.LoaderOptions
-import org.yaml.snakeyaml.Yaml
+import io.circe.yaml.Parser._
 import org.yaml.snakeyaml.constructor.SafeConstructor
 import org.yaml.snakeyaml.nodes._
+import org.yaml.snakeyaml.{LoaderOptions, Yaml}
+
+import java.io.{Reader, StringReader}
 import scala.collection.JavaConverters._
 
 final case class Parser(
@@ -56,7 +56,8 @@ object Parser {
       None
   }
 
-  private[yaml] class FlatteningConstructor extends SafeConstructor {
+  private[yaml] class FlatteningConstructor(val loaderOptions: LoaderOptions = new LoaderOptions)
+      extends SafeConstructor(loaderOptions) {
     def flatten(node: MappingNode): MappingNode = {
       flattenMapping(node)
       node

--- a/src/main/scala/io/circe/yaml/Parser.scala
+++ b/src/main/scala/io/circe/yaml/Parser.scala
@@ -3,12 +3,12 @@ package io.circe.yaml
 import cats.syntax.either._
 import io.circe._
 import io.circe.yaml.Parser._
+import java.io.{ Reader, StringReader }
+import org.yaml.snakeyaml.{ LoaderOptions, Yaml }
 import org.yaml.snakeyaml.constructor.SafeConstructor
 import org.yaml.snakeyaml.nodes._
-import org.yaml.snakeyaml.{ LoaderOptions, Yaml }
-
-import java.io.{ Reader, StringReader }
 import scala.collection.JavaConverters._
+
 
 final case class Parser(
   maxAliasesForCollections: Int = 50,

--- a/src/main/scala/io/circe/yaml/Parser.scala
+++ b/src/main/scala/io/circe/yaml/Parser.scala
@@ -11,12 +11,16 @@ import org.yaml.snakeyaml.nodes._
 import scala.collection.JavaConverters._
 
 final case class Parser(
-  maxAliasesForCollections: Int = 50
+  maxAliasesForCollections: Int = 50,
+  nestingDepthLimit: Int = 50,
+  codePointLimit: Int = 3 * 1024 * 1024 // 3 MB
 ) {
 
   private val loaderOptions = {
     val options = new LoaderOptions()
     options.setMaxAliasesForCollections(maxAliasesForCollections)
+    options.setNestingDepthLimit(nestingDepthLimit)
+    options.setCodePointLimit(codePointLimit)
     options
   }
 

--- a/src/test/scala/io/circe/yaml/ParserTests.scala
+++ b/src/test/scala/io/circe/yaml/ParserTests.scala
@@ -71,7 +71,6 @@ class ParserTests extends AnyFlatSpec with Matchers with EitherValues {
         .parse(
           ""
         )
-        .right
         .value == Json.False
     )
   }
@@ -82,7 +81,6 @@ class ParserTests extends AnyFlatSpec with Matchers with EitherValues {
         .parse(
           "   "
         )
-        .right
         .value == Json.False
     )
   }

--- a/src/test/scala/io/circe/yaml/ParserTests.scala
+++ b/src/test/scala/io/circe/yaml/ParserTests.scala
@@ -122,4 +122,59 @@ class ParserTests extends AnyFlatSpec with Matchers with EitherValues {
         .isLeft
     )
   }
+
+  it should "parse when within depth limits" in {
+    assert(
+      Parser(nestingDepthLimit = 3)
+        .parse(
+          """
+            | foo:
+            |   bar:
+            |     baz
+            |""".stripMargin
+        )
+        .isRight
+    )
+  }
+
+  it should "fail to parse when depth limit is exceeded" in {
+    assert(
+      Parser(nestingDepthLimit = 1)
+        .parse(
+          """
+            | foo:
+            |   bar:
+            |     baz
+            |""".stripMargin
+        )
+        .isLeft
+    )
+  }
+
+  it should "parse when within code point limit" in {
+    assert(
+      Parser(codePointLimit = 1 * 1024 * 1024) // 1MB
+        .parse(
+          """
+            | foo:
+            |   bar:
+            |     baz
+            |""".stripMargin
+        )
+        .isRight
+    )
+  }
+
+  it should "fail to parse when code point limit is exceeded" in {
+    assert(
+      Parser(codePointLimit = 13) // 13B
+        .parse(
+          """
+            | foo:
+            |   bar
+            |""".stripMargin
+        )
+        .isLeft
+    )
+  }
 }


### PR DESCRIPTION
This addresses [#332](https://github.com/circe/circe-yaml/issues/332).

SnakeYaml sets various default limits, and supports overriding these values via [LoaderOptions](https://www.javadoc.io/doc/org.yaml/snakeyaml/latest/org/yaml/snakeyaml/LoaderOptions.html).

This PR enables customisation of these limits, following a similar pattern as https://github.com/circe/circe-yaml/pull/205.